### PR TITLE
清除 redis 数据 支持密码配置

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -18,11 +18,3 @@ if (!defined('SWOOLE_PROCESS')) {
 if (!defined('SWOOLE_HOOK_ALL')) {
     define('SWOOLE_HOOK_ALL', 1879048191);
 }
-
-if (!function_exists('defer')) {
-    function defer($callback){}
-}
-
-if (!function_exists('go')) {
-    function go($func){}
-}

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -18,3 +18,11 @@ if (!defined('SWOOLE_PROCESS')) {
 if (!defined('SWOOLE_HOOK_ALL')) {
     define('SWOOLE_HOOK_ALL', 1879048191);
 }
+
+if (!function_exists('defer')) {
+    function defer($callback){}
+}
+
+if (!function_exists('go')) {
+    function go($func){}
+}

--- a/src/websocket/room/Redis.php
+++ b/src/websocket/room/Redis.php
@@ -78,6 +78,9 @@ class Redis implements RoomInterface
 
         $redis = new PHPRedis();
         $redis->connect($host, $port);
+        if ($password = Arr::get($this->config, 'password')) {
+            $redis->auth($password);
+        }
         if (count($keys = $redis->keys("{$this->prefix}*"))) {
             $redis->del($keys);
         }


### PR DESCRIPTION
升级 `3.0.6` 后 启动服务会有以下异常
> Call to undefined function Smf\ConnectionPool\go()

> Call to undefined function think\swoole\concerns\defer()

追加以上两个访问 启动正常。

以及 `room/Redis.php` `initData()` 清除数据时 支持密码配置