### PR TITLE
修正因一处参数不能为空导致 think-swoole终端报错的bug

### DIFF
--- a/src/concerns/InteractsWithHttp.php
+++ b/src/concerns/InteractsWithHttp.php
@@ -199,7 +199,9 @@ trait InteractsWithHttp
         $chunkSize = 8192;
 
         foreach (str_split($content, $chunkSize) as $chunk) {
-            $res->write($chunk);
+            if(!empty($chunk)) {
+                $res->write($chunk);
+            }
         }
 
         $res->end();


### PR DESCRIPTION
修正以下报错
```
[think\exception\ErrorException]
  Swoole\Http\Response::write(): data to send is empty
```