### PR TITLE
修复循环引用导致的内存增长问题

### DIFF
--- a/src/Sandbox.php
+++ b/src/Sandbox.php
@@ -101,6 +101,12 @@ class Sandbox
     public function clear($snapshot = true)
     {
         if ($snapshot) {
+            $snapshotInstance = $this->getSnapshot();
+            if($snapshotInstance) {
+                foreach($snapshotInstance as $k => $v) {
+                    unset($snapshotInstance[$k]);
+                }
+            }
             unset($this->snapshots[$this->getSnapshotId()]);
         }
 


### PR DESCRIPTION
每次请求后内存一直在大量增长，发现是`think\Container->$instances`中有和 App 对象产生了循环引用问题，没有释放内存。