### PR TITLE
fix#179

### DIFF
--- a/src/Websocket.php
+++ b/src/Websocket.php
@@ -148,7 +148,7 @@ class Websocket
             $result = $this->server->task([
                 'action' => static::PUSH_ACTION,
                 'data'   => [
-                    'sender'      => $this->getSender(),
+                    'sender'      => $this->getSender()?:0,
                     'descriptors' => $fds,
                     'broadcast'   => $this->isBroadcast(),
                     'assigned'    => $assigned,

--- a/src/Websocket.php
+++ b/src/Websocket.php
@@ -148,7 +148,7 @@ class Websocket
             $result = $this->server->task([
                 'action' => static::PUSH_ACTION,
                 'data'   => [
-                    'sender'      => $this->getSender()?:0,
+                    'sender'      => $this->getSender() ?: 0,
                     'descriptors' => $fds,
                     'broadcast'   => $this->isBroadcast(),
                     'assigned'    => $assigned,


### PR DESCRIPTION
由于tp框架在6.0.4版本时修改了容器参数绑定的字段检测由isset()改为了array_key_exist()，导致了参数如果是null会出现不同的处理方法