### PR TITLE
启用热更新进程中的协程

### DIFF
--- a/src/concerns/InteractsWithServer.php
+++ b/src/concerns/InteractsWithServer.php
@@ -160,7 +160,7 @@ trait InteractsWithServer
             $watcher->watch(function () {
                 $this->getServer()->reload();
             });
-        }, false, 0);
+        }, false, 0, true);
 
         $this->addProcess($process);
     }


### PR DESCRIPTION
swoole 版本： v4.6.0 ([Swoole v4.6.0 版本发布，支持原生 curl 协程客户端](https://segmentfault.com/a/1190000038848791))
think-swoole 版本：v3.0.10

开启热更新后提示如下：
```
PHP Fatal error:  Uncaught think\exception\ErrorException: Swoole\Event::rshutdown(): Event::wait() in shutdown function is deprecated in Unknown:0
Stack trace:
#0 [internal function]: think\initializer\Error->appError(8192, 'Swoole\\Event::r...', 'Unknown', 0, NULL)
#1 [internal function]: Swoole\Event::rshutdown()
#2 {main}
  thrown in Unknown on line 0
```