### PR TITLE
Update InteractsWithServer.php to fix "swoole_set_process_name" not support in "cygwin"

### DIFF
--- a/src/concerns/InteractsWithServer.php
+++ b/src/concerns/InteractsWithServer.php
@@ -207,8 +207,8 @@ trait InteractsWithServer
      */
     protected function setProcessName($process)
     {
-        // Mac OSX不支持进程重命名
-        if (stristr(PHP_OS, 'DAR')) {
+        // Mac OSX不支持进程重命名 cygwin 也不支持进程重命名
+        if (stristr(PHP_OS, 'DAR') || stristr(PHP_OS,'CYGWIN')) {
             return;
         }
 


### PR DESCRIPTION
fix "swoole_set_process_name" not support in "cygwin"
修复 “cygwin”平台不支持 "swoole_set_process_name" 函数的问题