### PR TITLE
fix Call to undefined function think\swoole\pool\go() 报错

### DIFF
--- a/src/pool/Proxy.php
+++ b/src/pool/Proxy.php
@@ -44,7 +44,7 @@ abstract class Proxy
                 {
                     //强制回收内存，完成连接释放
                     Event::defer(function () {
-                        go("gc_collect_cycles");
+                        Coroutine::create("gc_collect_cycles");
                     });
                 }
 


### PR DESCRIPTION
修复当没有开启短命名时使用`go`方法报错
```
Uncaught Error: Call to undefined function think\\swoole\\pool\\go2()
```