### PR TITLE
fix: 修正依赖错误

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "sort-packages": true,
         "platform-check": false,
         "platform": {
-            "ext-swoole": "4.4.8",
+            "ext-swoole": "4.6.1",
             "ext-fileinfo": "1.0.4"
         }
     }


### PR DESCRIPTION
composer 依赖解决错误问题：
```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires PHP extension ext-swoole >=4.6 but it has the wrong version (4.4.8; overridden via config.platform, actual: 4.6.4) installed. Install or enable PHP's swoole extension.
```

ps: `platform`声明意义不大，是否考虑移除？