### PR TITLE
修复了在php开启了APC或OPcache的场景下，修改代码后swoole平滑重启不生效的问题。

### DIFF
--- a/src/Http.php
+++ b/src/Http.php
@@ -135,6 +135,14 @@ class Http extends Server
      */
     public function onWorkerStart($server, $worker_id)
     {
+        // 如果开启了APC或OPcache，还需要刷新缓存后，平滑重启才会生效。
+        if (extension_loaded('apc')) {
+            apc_clear_cache();
+        }
+        if (extension_loaded('Zend OPcache')) {
+            opcache_reset();
+        }
+
         // 应用实例化
         $this->app       = new Application($this->appPath);
         $this->lastMtime = time();


### PR DESCRIPTION
修复了在php开启了APC或OPcache的场景下，修改代码后swoole平滑重启不生效的问题。