### PR TITLE
配置优化

### DIFF
--- a/src/concerns/InteractsWithServer.php
+++ b/src/concerns/InteractsWithServer.php
@@ -31,8 +31,6 @@ trait InteractsWithServer
             'send_yield'            => true,
             'reload_async'          => true,
             'enable_coroutine'      => true,
-            'max_request'           => 0,
-            'task_max_request'      => 0,
         ]);
         $this->initialize();
         $this->triggerEvent('init');


### PR DESCRIPTION
一些不规范的代码导致缓慢内存遗漏，需要通过设置max_request去解决。

修复 在config/swoole.php options中设置不生效的问题