### PR TITLE
修复指定env时，热更新错误

### DIFF
--- a/src/concerns/InteractsWithServer.php
+++ b/src/concerns/InteractsWithServer.php
@@ -54,8 +54,10 @@ trait InteractsWithServer
         $this->initialize();
         $this->triggerEvent('init');
 
+        $this->container->loadEnv($envName);
+
         //热更新
-        if ($this->getConfig('hot_update.enable', false)) {
+        if ($this->container->env->get('app_debug', false) && $this->getConfig('hot_update.enable', false)) {
             $this->addHotUpdateProcess();
         }
 


### PR DESCRIPTION
使用`--env`指定文件时，初始化的时候`env`和`config`已经加载了一次，`getConfig`读到了默认的`.env`，而不是指定的，所以导致如果在指定的`env`中关闭了`app_debug`，也会设置热更新进程。

